### PR TITLE
Add ci->connectmillis as session identifier to the extended extinfo player reply

### DIFF
--- a/src/fpsgame/extinfo.h
+++ b/src/fpsgame/extinfo.h
@@ -59,7 +59,7 @@
         q.put((uchar*)&ip, 3);
         if(z_extended)
         {
-            putint(q, -1); //for hopmod compatibility
+            putint(q, -1); // for hopmod compatibility
             putint(q, EXT_SERVERMOD);
             putint(q, ci->state.suicides);
             putint(q, ci->state.shotdamage);
@@ -70,6 +70,7 @@
             putint(q, ci->state.shots);
             short gi = z_geoip_getextinfo(ci->xi.geoip);
             q.put((uchar*)&gi, 2);
+            putint(q, ci->connectmillis); // player session identifier (in combination with cn), sessionid would be too sensitive
         }
         sendserverinforeply(q);
     }


### PR DESCRIPTION
In combination with the player's client number this makes it possible to **reliably**
detect the online time of players, renames, etc... without the need of an ip address.

I am **not** interesting in using this for an alias bot (would be quite useless anyway),
it's for something else.

Replacing `ci->connectmillis` by a unique number (e.g. an increasing counter)
would be ok too.
